### PR TITLE
remove the DiffOp type, use ring elements and matrices instead?

### DIFF
--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -1775,11 +1775,9 @@ assert(all(hilb, maca, (i,j) -> i == j))
 ///
 
 -- computes the annihilator ideal of a polynomial F in a polynomial ring 
--- Input: a DiffOp. Output: a zero-dimension ideal that corresponds with the annihilator
+-- Input: a 1x1 matrix. Output: a zero-dimension ideal that corresponds with the annihilator
 polynomialAnn = (F') -> (
-    -- change the DiffOp to a RingElement. This assumes that
-    -- coefficients are in the coefficient ring.
-    F := keys F' / (k -> F'#k * k) // sum;
+    F := F'_(0,0);
     deg := (degree F)_0;
     S := ring F;
     allMons := basis(1, deg + 1, S);
@@ -1802,14 +1800,15 @@ vectorAnn = (V) -> (
 getIdealFromNoetherianOperators = method()
 getIdealFromNoetherianOperators(List, Ideal) := (L, P) -> (
     R := ring P;
-    if ring first L =!= R then error "expected Noetherian operators and prime in same ring";
+    if coefficientRing ring first L =!= R then error "expected Noetherian operators and prime in same ring";
     indVars := support first independentSets P;
     FF := frac(R/P);
     S := FF monoid R;
 
-    mapDiff := map(S,R, vars S);
+    mapDiff := map(S,ring first L, vars S);
     mapCoef := map(coefficientRing S, R);
-    V := L / (op -> applyPairs(op, (a,b) -> (mapDiff a, promote(mapCoef b,S))));
+    V := L / coefficients / ((a,b) -> (mapDiff a * mapCoef sub(b, R)));
+    --V := L / (op -> applyPairs(op, (a,b) -> (mapDiff a, promote(mapCoef lift(b, R),S))));
 
     I := vectorAnn(V);
     R' := R monoid R;

--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -19,7 +19,7 @@ newPackage(
     PackageExports => {"Bertini", "NumericalLinearAlgebra", "NAGtypes"},
     PackageImports => {"Dmodules", "PrimaryDecomposition"},
     AuxiliaryFiles => false,
-    DebuggingMode => false,
+    DebuggingMode => true, --TODO
     Keywords => {"Numerical Algebraic Geometry", "Commutative Algebra"}
 )
 
@@ -945,13 +945,16 @@ macaulayMatrixKernel := true >> opts -> (I, kP) -> (
 
 -- returns a list of Diff ops based on matrices M, dBasis
 matrixToDiffOps = (M, dBasis) -> (
-    if M == 0 then {new ZeroDiffOp from ring M}
-    else transpose entries M / 
-        (c -> apply(flatten entries dBasis, c, identity)) /
-        diffOp //
-        sort
+    R := ring M;
+    S := diffOpRing R;
+    phi := map(S,R, gens S);
+    if M == 0 then 0_S
+    else transpose entries M /
+        (c -> phi dBasis * transpose matrix {c})
+    --TODO sort?
 )
 
+diffOpRing = (cacheValue "DiffOpRing") (R -> R(monoid [gens R / toString / (v -> "d" | v) / value]))
 
 noetherianOperatorsViaMacaulayMatrix = method(Options => true) 
 noetherianOperatorsViaMacaulayMatrix (Ideal, Ideal) := List => true >> opts -> (I, P) -> (

--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -1439,7 +1439,7 @@ modConstant = f -> (
 amult = method()
 amult Module := ZZ => M -> (
     assPrimes := ass(comodule M);
-    sum apply(assPrimes, P -> degree(saturate(M,P)/M)/degree(P))
+    sum apply(assPrimes, P -> degree(saturate(M,P)/M)//degree(P))
 )
 amult Ideal := ZZ => I -> amult module I
 

--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -680,9 +680,7 @@ isPointEmbeddedInCurve (Point,Ideal) := o-> (p,I) -> (
 DiffOp = new Type of Vector
 DiffOp.synonym = "differential operator"
 
--- new Module of DiffOp from Module := (M,D, m) -> (
---     m
--- )
+diffOpModule = memoize((S, k) -> new Module of DiffOp from S^k)
 
 diffOp = method()
 diffOp Matrix := m -> (
@@ -690,7 +688,7 @@ diffOp Matrix := m -> (
     if S.?cache and S.cache#?"DiffOpRing" then (S = diffOpRing S; m = sub(m,S);)
     else if S =!= diffOpRing coefficientRing S then error"expected ring element in diffOpRing";
     
-    SS := new Module of DiffOp from S^(numRows m);
+    SS := diffOpModule(S, numRows m);
     new SS from vector m
 )
 diffOp RingElement := f -> diffOp matrix f

--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -59,9 +59,12 @@ export {
     "TrustedPoint",
 
     --functions from punctual Hilb approach
-    "getIdealFromNoetherianOperators",
+    -- "getIdealFromNoetherianOperators",
     "joinIdeals",
-    "mapToPunctualHilbertScheme" 
+    "amult",
+    "solvePDE",
+    "diffPrimDec"
+    -- "mapToPunctualHilbertScheme" 
 
 }
 
@@ -1434,10 +1437,9 @@ localize(Module, Ideal, List) := Module => opts -> (M, P, L) -> (
     if #g == 0 then M else saturate(M, lcm g)
 )
 
-solvePDE = method(Options => {Prefix => "d"})
-solvePDE(Module) := List => opts -> M -> (
+solvePDE = method(Options => true)
+solvePDE(Module) := List => true >> opts -> M -> (
     R := ring M;
-    error"dbg";
     -- if not instance(opts.Prefix, String) then error "expected prefix of class String";
     -- prefix = opts.Prefix;
     -- Pvars := gens R / toString / (i -> prefix | i);
@@ -1454,7 +1456,9 @@ solvePDE(Module) := List => opts -> M -> (
         {P, reducedNoetherianOperators(a,b,P, opts)}
     ))
 )
-solvePDE(Ideal) := List => opts -> I -> solvePDE (module I, opts)
+solvePDE(Ideal) := List => true >> opts -> I -> solvePDE (module I, opts)
+
+diffPrimDec = solvePDE
 
 
 reducedNoetherianOperators = method(Options => true)

--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -981,7 +981,8 @@ TEST ///
 debug NoetherianOperators
 R = QQ[x,y,t]
 I = ideal(x^2, y^2 - t*x)
-nops = noetherianOperatorsViaMacaulayMatrix(I) / normalize
+-- TODO nops = noetherianOperatorsViaMacaulayMatrix(I) / normalize
+nops = noetherianOperatorsViaMacaulayMatrix(I)
 correct = {diffOp{1_R => 1}, diffOp{y => 1}, diffOp{y^2 => t, x => 2}, diffOp{y^3 => t, x*y => 6}}
 assert(all(nops, correct, (i,j) -> i == j))
 
@@ -989,7 +990,8 @@ S = QQ[x,y]
 J = ideal(x^3, y^4, x*y^2)
 
 correct = sort {diffOp{1_S => 1},diffOp{x => 1},diffOp{y => 1},diffOp{x^2 => 1},diffOp{x*y => 1},diffOp{y^2 => 1},diffOp{x^2*y => 1},diffOp{y^3 => 1}}
-nops = noetherianOperatorsViaMacaulayMatrix(J) / normalize
+--TODO nops = noetherianOperatorsViaMacaulayMatrix(J) / normalize
+nops = noetherianOperatorsViaMacaulayMatrix(J)
 assert(all(nops, correct, (i,j) -> i == j))
 ///
 
@@ -1073,8 +1075,9 @@ hybridNoetherianOperators (Ideal, Ideal, Matrix) := List => true >> opts -> (I,P
     kP := toField(S/PS);
     RCC := (ring pt) monoid R;
     nopsAtPoint := numNoethOpsAtPoint(sub(I,RCC), pt, opts, DependentSet => depVars / (i->sub(i,RCC)), IntegralStrategy => false);
-    sort flatten for op in nopsAtPoint list (
-        dBasis := sub(matrix{sort keys op / (m -> R_(first exponents m))}, S);
+    -- sort flatten for op in nopsAtPoint list (
+    flatten for op in nopsAtPoint list (
+        dBasis := sub(matrix{flatten entries monomials op / (m -> R_(first exponents m))}, S);
         maxdeg := flatten entries dBasis / sum @@ degree // max;
         K := dBasis;
         for d from 0 to maxdeg - 1 do (

--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -680,9 +680,35 @@ isPointEmbeddedInCurve (Point,Ideal) := o-> (p,I) -> (
 DiffOp = new Type of Vector
 DiffOp.synonym = "differential operator"
 
-new Module of DiffOp from Module := (M,D, m) -> (
-    m
+-- new Module of DiffOp from Module := (M,D, m) -> (
+--     m
+-- )
+
+diffOp = method()
+diffOp Matrix := m -> (
+    S := ring m;
+    if S.?cache and S.cache#?"DiffOpRing" then (S = diffOpRing S; m = sub(m,S);)
+    else if S =!= diffOpRing coefficientRing S then error"expected ring element in diffOpRing";
+    
+    SS := new Module of DiffOp from S^(numRows m);
+    new SS from vector m
 )
+diffOp RingElement := f -> diffOp matrix f
+
+DiffOp ? DiffOp := (a,b) -> (
+    if #(entries a) != #(entries b) then incomparable
+    else if (class a) != (class b) then incomparable;
+    delta := a - b;
+    i := position(entries delta, j -> j != 0);
+    if instance(i, Nothing) then symbol ==
+    else ((entries a)#i) ? ((entries b)#i)
+)
+DiffOp == DiffOp := (a,b) -> (
+    if ((a ? b) === incomparable) then error("expected comparable differential operators")
+    else if ((a ? b) === (symbol ==)) then true
+    else false
+)
+
 
 DiffOp SPACE Matrix := (D,m) -> (
     if numColumns m != 1 then error"expected column matrix";
@@ -712,8 +738,18 @@ assert(instance(SS_0, DiffOp))
 assert(instance(dx*SS_0 + 3*SS_1, DiffOp))
 assert(instance(d, DiffOp))
 
-m = transpose matrix {{x*y + 5, x^2*y^2}}
+m = matrix transpose {{x*y + 5, x^2*y^2}}
 assert(d m == y^3 -x^2*y - 5*x + y*4*y )
+
+m = matrix transpose{{dx, y*dy*dx+dx^2+dy}}
+a = diffOp m
+b = (dx*SS_0 + (y*dy*dx+dx^2+dy)*SS_1)
+assert(a==b)
+
+SS = new Module of DiffOp from S^1
+assert(diffOp (x^2*dx) == x^2*dx*SS_0)
+assert(diffOp(x_R) == x*SS_0)
+assert(diffOp(x_S) == x*SS_0)
 ///
 
 

--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -1436,15 +1436,16 @@ localize(Module, Ideal, List) := Module => opts -> (M, P, L) -> (
 
 solvePDE = method(Options => {Prefix => "d"})
 solvePDE(Module) := List => opts -> M -> (
-    if not instance(opts.Prefix, String) then error "expected prefix of class String";
-    prefix = opts.Prefix;
-    Pvars := gens R / toString / (i -> prefix | i);
+    R := ring M;
+    error"dbg";
+    -- if not instance(opts.Prefix, String) then error "expected prefix of class String";
+    -- prefix = opts.Prefix;
+    -- Pvars := gens R / toString / (i -> prefix | i);
 
     -- Create a new ring with the above variables if needed, cache it in R
-    R := ring M;
-    if not R.?cache then R.cache = new CacheTable;
-    key := prefix | "-variable ring";
-    if not R.cache#?key then R.cache#key = (coefficientRing R)(monoid [((gens R / toString) | Pvars) / value]);
+    -- if not R.?cache then R.cache = new CacheTable;
+    -- key := prefix | "-variable ring";
+    -- if not R.cache#?key then R.cache#key = (coefficientRing R)(monoid [((gens R / toString) | Pvars) / value]);
 
     assPrimes := ass(comodule M);
     assPrimes / (P -> (
@@ -1457,7 +1458,7 @@ solvePDE(Ideal) := List => opts -> I -> solvePDE (module I, opts)
 
 
 reducedNoetherianOperators = method(Options => true)
-reducedNoetherianOperators (Module, Module, Ideal) := List => opts -> (a,b,P) -> (
+reducedNoetherianOperators (Module, Module, Ideal) := List => true >> opts -> (a,b,P) -> (
     R := ring P;
     --if not instance(opts.Prefix, String) then error "expected prefix of class String";
     --prefix = opts.Prefix;


### PR DESCRIPTION
- [x] Use `diffOpRing` to access (or create) the ring with `2n` variables
- [ ] allow different prefixes for `diffOpRing`
- [x] implement the operation `(diffOpRing R) SPACE R`
- [x] implement the same operation for modules
- [x] idea: wrap a column matrix of elements of `diffOpRing R` into a new type
- [X] Fix `noethOpsViaMacaulayMatrix`
- [x] Fix `hybridNoethOps`
- [x] Fix `punctualNoethOps`
- [x] Fix `numericalNoethOps`
- [x] Fix tests